### PR TITLE
Fix herb gathering card style

### DIFF
--- a/components/links-section/herb-gathering-card.vue
+++ b/components/links-section/herb-gathering-card.vue
@@ -10,7 +10,7 @@
         class="h-full w-full duration-1500 group-hover:scale-120"
       />
       <span
-        class="text-primary li link-card-title absolute top-[10%] left-[10%] leading-none sm:top-[48px] sm:left-[55px]"
+        class="text-primary link-card-title absolute top-[10%] left-[10%] leading-none sm:top-[48px] sm:left-[55px]"
       >
         СБОР<br />ТРАВ
       </span>


### PR DESCRIPTION
## Summary
- remove stray `li` class from herb gathering card span

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846dda3c4888326a953013cd5e7c32f