### PR TITLE
Add lazy loading component for images

### DIFF
--- a/components/contacts-section.vue
+++ b/components/contacts-section.vue
@@ -1,14 +1,14 @@
 <template>
   <section id="reservation" class="relative overflow-hidden">
-    <nuxt-img
+    <lazy-image
       src="/images/contacts/background.jpg"
       class="h-[150px] w-full object-cover sm:h-[200px] md:h-[250px] lg:h-[300px] xl:h-full"
     />
-    <nuxt-img
+    <lazy-image
       src="/images/contacts/decoration-1.png"
       class="absolute top-0 right-0 z-2 w-[80%] md:w-[60%]"
     />
-    <nuxt-img
+    <lazy-image
       src="/images/contacts/decoration-2.png"
       class="3xl:max-h-[2600px] absolute top-0 left-[220px] z-3 w-full max-xl:hidden xl:max-h-[2000px] 2xl:max-h-[2300px]"
     />

--- a/components/links-section/arrival-dates-card.vue
+++ b/components/links-section/arrival-dates-card.vue
@@ -3,11 +3,11 @@
     class="group link-card relative overflow-hidden rounded-[40px]"
     @click="isModalOpen = !isModalOpen"
   >
-    <nuxt-img
+    <lazy-image
       src="/images/links/2.png"
       class="h-full w-full duration-1500 group-hover:scale-120"
     />
-    <nuxt-img
+    <lazy-image
       src="/images/links/2-bg.png"
       class="absolute bottom-0 left-0 w-[93%]"
     />

--- a/components/links-section/creative-retreat-card.vue
+++ b/components/links-section/creative-retreat-card.vue
@@ -12,7 +12,7 @@
       >
         ТВОРЧЕСКАЯ <br />ЗДРАВНИЦА
       </span>
-      <nuxt-img
+      <lazy-image
         src="/images/links/9.png"
         class="absolute right-0 bottom-0 h-[65%] duration-1500 group-hover:scale-120"
       />

--- a/components/links-section/gallery-card.vue
+++ b/components/links-section/gallery-card.vue
@@ -10,7 +10,7 @@
       >
         ГАЛЕРЕЯ
       </span>
-      <nuxt-img
+      <lazy-image
         src="/images/links/5.png"
         class="h-full w-full duration-1500 group-hover:scale-120"
       />

--- a/components/links-section/healthy-nutrition-card.vue
+++ b/components/links-section/healthy-nutrition-card.vue
@@ -5,7 +5,7 @@
     class="link-card"
   >
     <article class="group relative overflow-hidden rounded-[40px]">
-      <nuxt-img
+      <lazy-image
         src="/images/links/4.png"
         class="h-full w-full duration-1500 group-hover:scale-120"
       />

--- a/components/links-section/herb-gathering-card.vue
+++ b/components/links-section/herb-gathering-card.vue
@@ -5,7 +5,7 @@
     class="link-card"
   >
     <article class="group relative overflow-hidden rounded-[40px]">
-      <nuxt-img
+      <lazy-image
         src="/images/links/1.png"
         class="h-full w-full duration-1500 group-hover:scale-120"
       />

--- a/components/links-section/our-doctors-card.vue
+++ b/components/links-section/our-doctors-card.vue
@@ -10,7 +10,7 @@
         НАШИ <br />ВРАЧИ
       </span>
     </div>
-    <nuxt-img
+    <lazy-image
       src="/images/links/8.png"
       class="h-full w-full duration-1500 group-hover:scale-120"
     />

--- a/components/links-section/recommendations-card.vue
+++ b/components/links-section/recommendations-card.vue
@@ -5,7 +5,7 @@
     class="link-card"
   >
     <article class="group relative overflow-hidden rounded-[40px]">
-      <nuxt-img
+      <lazy-image
         src="/images/links/7.png"
         class="h-full w-full duration-1500 group-hover:scale-120"
       />

--- a/components/links-section/rooms-card.vue
+++ b/components/links-section/rooms-card.vue
@@ -12,7 +12,7 @@
           НОМЕРА
         </span>
       </div>
-      <nuxt-img
+      <lazy-image
         src="/images/links/3.png"
         class="h-full w-full duration-1500 group-hover:scale-120"
       />

--- a/components/links-section/wellness-tips-card.vue
+++ b/components/links-section/wellness-tips-card.vue
@@ -12,7 +12,7 @@
           СОВЕТЫ ПО <br />ОЗДОРОВЛЕНИЮ
         </span>
       </div>
-      <nuxt-img
+      <lazy-image
         src="/images/links/6.png"
         class="h-full w-full duration-1500 group-hover:scale-120"
       />

--- a/components/main-footer.vue
+++ b/components/main-footer.vue
@@ -8,19 +8,19 @@
       class="flex flex-row items-center justify-center gap-2 md:gap-10 xl:gap-20 2xl:gap-40"
     >
       <a href="tel:+79878003413" type="phone">
-        <nuxt-img
+        <lazy-image
           src="/images/footer/phone.png"
           class="size-[60px] md:size-[100px] 2xl:size-[140px]"
         />
       </a>
       <a href="https://wa.me/79878003413" target="_blank">
-        <nuxt-img
+        <lazy-image
           src="/images/footer/whatsapp.png"
           class="size-[60px] md:size-[100px] 2xl:size-[140px]"
         />
       </a>
       <a href="https://vk.com/yagodnaypolyana" target="_blank">
-        <nuxt-img
+        <lazy-image
           src="/images/footer/vk.png"
           class="size-[60px] md:size-[100px] 2xl:size-[140px]"
         />

--- a/components/main-header.vue
+++ b/components/main-header.vue
@@ -3,7 +3,7 @@
     class="bg-white-secondary flex h-[80px] items-center gap-[30px] px-[20px] py-[10px] sm:h-[120px] md:gap-[50px] md:py-[40px] lg:h-[150px]"
   >
     <div class="grow cursor-pointer" @click="scrollTo('main')">
-      <nuxt-img
+      <lazy-image
         src="/images/logo/logo-header.png"
         alt="Ягодная поляна - логотип"
         class="3xl:h-[150px] h-[50px] sm:h-[80px] md:h-[100px] lg:h-[120px]"

--- a/components/main-section.vue
+++ b/components/main-section.vue
@@ -3,20 +3,20 @@
     id="main"
     class="group relative [height:calc(100vh-100px)] overflow-hidden md:[height:calc(100vh-120px)] lg:[height:calc(100vh-150px)]"
   >
-    <nuxt-img
+    <lazy-image
       src="/images/main-bg.jpg"
       class="h-full w-full object-cover transition-all duration-2000 group-hover:scale-120"
     />
     <div
       class="section-container absolute top-1/2 left-1/2 w-[80%] -translate-x-1/2 -translate-y-1/2 text-white"
     >
-      <nuxt-img
+      <lazy-image
         src="/images/logo/logo-min.png"
         class="mx-auto block md:hidden"
         alt="Логотип (мобильный)"
       />
 
-      <nuxt-img
+      <lazy-image
         src="/images/logo/logo-big.png"
         class="mx-auto hidden md:block"
         alt="Логотип (десктоп)"

--- a/components/modal/price.vue
+++ b/components/modal/price.vue
@@ -22,7 +22,7 @@
         </ul>
       </div>
 
-      <nuxt-img
+      <lazy-image
         src="/images/price/decoration-1.png"
         class="absolute top-0 right-0 hidden h-full 2xl:block"
       />

--- a/components/modal/principles-health.vue
+++ b/components/modal/principles-health.vue
@@ -16,7 +16,7 @@
           <p class="text-white-secondary">
             {{ index + 1 }}
           </p>
-          <nuxt-img
+          <lazy-image
             :src="principle.img"
             :alt="principle.title"
             class="3xl:size-[160px] size-[60px] sm:size-[80px] xl:size-[120px]"

--- a/components/ui/lazy-image.vue
+++ b/components/ui/lazy-image.vue
@@ -1,0 +1,16 @@
+<template>
+  <nuxt-img
+    v-bind="$attrs"
+    class="opacity-0 transition-opacity duration-700"
+    :class="{ 'opacity-100': loaded }"
+    loading="lazy"
+    @load="onLoad"
+  />
+</template>
+
+<script setup lang="ts">
+const loaded = ref(false)
+const onLoad = () => {
+  loaded.value = true
+}
+</script>


### PR DESCRIPTION
## Summary
- create `LazyImage` component that fades images in after load
- replace `nuxt-img` tags with `LazyImage` for all images

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e1f68ad88326807427879f602d75